### PR TITLE
Build version npm scripts – à tester

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,36 @@
-node_modules
+/node_modules
+/.idea
+
+## https://help.github.com/articles/ignoring-files
+
+# Compiled source #
+###################
+*.com
+*.class
+*.dll
+*.exe
+*.o
+*.so
+
+# Packages #
+############
+# it's better to unpack these files and commit the raw source
+# git has its own built in compression methods
+*.7z
+*.dmg
+*.gz
+*.iso
+*.jar
+*.rar
+*.tar
+*.zip
+
+# OS generated files #
+######################
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db

--- a/package.json
+++ b/package.json
@@ -1,11 +1,18 @@
 {
   "name": "tinytypo",
-  "version": "1.3",
+  "version": "1.3.0",
   "description": "Tiny Typo est une base CSS pour le contenu éditorial web",
   "main": "css/tinytypo.css",
   "repository": {
     "type": "git",
     "url": "git://github.com/tetue/tinytypo"
+  },
+  "scripts": {
+    "build": "node_modules/.bin/lessc less/tinytypo.less css/tinytypo.css",
+    "watch": "node_modules/.bin/watch-exec -c 'npm run-script build' -w less/",
+    "serve": "node_modules/.bin/http-server",
+    "open": "node_modules/.bin/opener http://127.0.0.1:8080/tinytypo.html",
+    "dev": "node_modules/.bin/npm-run-all --parallel watch serve open"
   },
   "homepage": "http://tinytypo.tetue.net/",
   "keywords": [
@@ -20,5 +27,12 @@
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/tetue/tinytypo/issues"
+  },
+  "devDependencies": {
+    "http-server": "^0.9.0",
+    "less": "^2.7.1",
+    "npm-run-all": "^1.8.0",
+    "watch-exec": "^1.2.2",
+    "open": "0.0.5"
   }
 }


### PR DESCRIPTION
Pour tester :  

* faire un `npm install` dans le répertoire
* Lancer l'outillage avec `npm run dev`

*Normalement*, ça devrait également fonctionner sous windows.